### PR TITLE
Use `github.ref_name`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         fi
 
         composer require --update-with-all-dependencies ${{ env.COMPOSER_PACKAGE_PREREQUISITES }} ${{ env.ADDITIONAL_COMPOSER_PACKAGE_PREREQUISITES }} \
-          "${{ inputs.composer_package }}:dev-${{ github.base_ref }}#${{ github.sha }}"
+          "${{ inputs.composer_package }}:dev-${{ github.ref_name }}#${{ github.sha }}"
 
         # XXX: Trying to run PHPUnit complains w/o prophecy-phpunit:
         # > Drupal requires Prophecy PhpUnit when using PHPUnit 9 or greater.


### PR DESCRIPTION
`github.base_ref` is only relevant for pull requests, but we would like to be able to have things usable via `workflow_dispatch` and the like.