### PR TITLE
github.base_ref only exists in context of a pull request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         fi
 
         composer require --update-with-all-dependencies ${{ env.COMPOSER_PACKAGE_PREREQUISITES }} ${{ env.ADDITIONAL_COMPOSER_PACKAGE_PREREQUISITES }} \
-          "${{ inputs.composer_package }}:dev-${{ github.base_ref }}#${{ github.sha }}"
+          "${{ inputs.composer_package }}:dev-${{ github.ref }}#${{ github.sha }}"
 
         # XXX: Trying to run PHPUnit complains w/o prophecy-phpunit:
         # > Drupal requires Prophecy PhpUnit when using PHPUnit 9 or greater.


### PR DESCRIPTION
Implementing a reference to the work that should be resolvable in the instances where we run this as a `workflow_dispatch`.