### PR TITLE
TWM-52: Avoid attempting to bind the branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         fi
 
         composer require --update-with-all-dependencies ${{ env.COMPOSER_PACKAGE_PREREQUISITES }} ${{ env.ADDITIONAL_COMPOSER_PACKAGE_PREREQUISITES }} \
-          "${{ inputs.composer_package }}:dev-${{ github.ref_name }}#${{ github.sha }}"
+          "${{ inputs.composer_package }}:dev-main#${{ github.sha }}"
 
         # XXX: Trying to run PHPUnit complains w/o prophecy-phpunit:
         # > Drupal requires Prophecy PhpUnit when using PHPUnit 9 or greater.


### PR DESCRIPTION
Doesn't _really_ matter, and `main` should always be there.