### PR TITLE
[SUP-7562] Adjust `VERSION_SPEC`

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -94,7 +94,7 @@ jobs:
           apt-get install -y postgresql-client
           PGHOST=postgres PGUSER=drupal PGPASSWORD=drupal psql --command='CREATE EXTENSION pg_trgm;' drupal
       - name: Run PHPUnit Action
-        uses: discoverygarden/phpunit-action@adam-vessey-patch-1
+        uses: discoverygarden/phpunit-action@v1
         with:
           composer_package_prerequisites: ${{ inputs.composer_prereqs }}
           composer_patches: ${{ inputs.composer_patches }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -94,7 +94,7 @@ jobs:
           apt-get install -y postgresql-client
           PGHOST=postgres PGUSER=drupal PGPASSWORD=drupal psql --command='CREATE EXTENSION pg_trgm;' drupal
       - name: Run PHPUnit Action
-        uses: discoverygarden/phpunit-action@v1
+        uses: discoverygarden/phpunit-action@adam-vessey-patch-1
         with:
           composer_package_prerequisites: ${{ inputs.composer_prereqs }}
           composer_patches: ${{ inputs.composer_patches }}

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,11 @@ runs:
         fi
 
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] ; then
-          VERSION_SPEC="${{ github.ref_name }}"
+          if [[ "${{ github.ref_type }}" == "branch" ]] ; then
+            VERSION_SPEC="dev-${{ github.ref_name }}"
+          else
+            VERSION_SPEC="${{ github.ref_name }}"
+          fi
         else
           VERSION_SPEC="dev-${{ github.sha }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,11 @@ runs:
           echo "Not doing the lenient thing."
         fi
 
-        VERSION_SPEC="dev-${{ github.sha }}"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] ; then
+          VERSION_SPEC="${{ github.ref_name }}"
+        else
+          VERSION_SPEC="dev-${{ github.sha }}"
+        fi
 
         composer require --update-with-all-dependencies ${{ env.COMPOSER_PACKAGE_PREREQUISITES }} ${{ env.ADDITIONAL_COMPOSER_PACKAGE_PREREQUISITES }} \
           "${{ inputs.composer_package }}:$VERSION_SPEC"


### PR DESCRIPTION
It appears that dispatched workflows don't expose things in quite the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized workflow configuration formatting with consistent line endings
  * Enhanced package version selection logic to dynamically vary based on workflow trigger type and Git reference type, differentiating between manual dispatches and automated executions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->