### PR TITLE
[SEC-2830] mark drupal 11.3 with php 8.4 not experimental

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -60,8 +60,7 @@ jobs:
           #  do-leniency: true
           - drupal-version: '11.3'
             php-version: '8.4'
-            # XXX: experimental, for now.
-            experimental: true
+            experimental: false
             do-leniency: true
           - drupal-version: '11.3'
             php-version: '8.5'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to mark Drupal 11.3 with PHP 8.4 support as stable rather than experimental.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/discoverygarden/phpunit-action/pull/32)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->